### PR TITLE
Prevent collapse component firing form submitting

### DIFF
--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -99,7 +99,7 @@ const Collapse: FunctionComponent<CollapseProps> = props => {
         {props.headerComponent}
       </CustomHeader>
     ) : (
-      <DefaultHeader {...defaultProps} theme={theme} appearance="text" aria-label={props.headerTitleText}>
+      <DefaultHeader {...defaultProps} theme={theme} appearance="text" type="button" aria-label={props.headerTitleText}>
         {props.headerTitleText}
         <FlippingIcon name="chevronRight" active={activeStatus} />
       </DefaultHeader>


### PR DESCRIPTION
Added type="button" to collapse component to prevent it submitting a form when used inside.