### PR TITLE
Collapse fix tabbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "0.1.0-alpha.76",
+  "version": "0.1.0-alpha.77",
   "description": "React components implementing CRUK and SU2C designs",
   "license": "UNLICENSED",
   "publishConfig": {

--- a/src/components/Collapse/README.md
+++ b/src/components/Collapse/README.md
@@ -7,7 +7,7 @@ Use a collapse component to show and hide content. It has a default view; howeve
 ```.jsx
 <>
     <Collapse headerTitleText="What is Lorem Ipsum?" id="default">
-      <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+      <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of <Link href="/">Lorem Ipsum</Link></p>
     </Collapse>
 
     <Collapse

--- a/src/components/Collapse/index.tsx
+++ b/src/components/Collapse/index.tsx
@@ -66,12 +66,14 @@ const DefaultHeader = styled(Button)<StyledProgressBarProps>`
 
 type CollapseContentProps = {
   contentHeight: string;
+  openStatus: boolean;
 };
 
 const CollapseContent = styled.div<CollapseContentProps>`
   margin: 0;
   transition: ${transitionDurationSeconds}s ease;
   height: ${({ contentHeight }) => contentHeight};
+  visibility: ${({ openStatus }) => openStatus ? 'visible' : 'hidden'};
   overflow: hidden;
   & > p {
     margin-top: 0;
@@ -170,6 +172,7 @@ const Collapse: FunctionComponent<CollapseProps> = props => {
         aria-hidden={!openStatus}
         aria-labelledby={`${id}-header`}
         contentHeight={contentHeight}
+        openStatus={openStatus}
       >
         {children}
       </CollapseContent>


### PR DESCRIPTION
We want to prevent users being able to tab into a closed collapse component. While visibility: hidden isnt animated it is applied at the end of the transition meaning that we fix the issue without effecting the appearance of the transition. I have added a link into the paragraph in the documentation so this can be easily demonstrated.

![Mar-01-2021 16-06-09](https://user-images.githubusercontent.com/2520859/109524775-cac5ff00-7aa8-11eb-9629-f502ba24023f.gif)

