### PR TITLE
Links as Buttons

### DIFF
--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -66,6 +66,9 @@ const GlobalStyle = createGlobalStyle`
   section {
     width: 100%;
   }
+  button {
+    font-size: 1em;
+  }
 `;
 
 export default withTheme(GlobalStyle);

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -33,6 +33,9 @@ type StyledLinkProps = AnchorHTMLAttributes<HTMLElement> &
 
 const StyledLink = styled(Text)<StyledLinkProps>`
   transition: color 0.2s ease;
+  background-color: rgba(255, 255, 255, 0);
+  border: none;
+  padding: 0;
   color: ${({ theme: { colors }, textColor, appearance }) =>
     textColor && typeof colors[textColor] !== 'undefined'
       ? colors[textColor]


### PR DESCRIPTION
when using styled components polymorphism <Link as="button"> make sure Link still looks like a link and override browser default button styles