### PR TITLE
Input props

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -15,21 +15,14 @@ const Checkbox: FC<CheckboxProps> = forwardRef((props: CheckboxProps, ref?: Ref<
     ...defaultTheme,
     ...foundTheme,
   };
+  const { children, ...propsWithoutChildren } = props;
 
   return (
     <ThemeProvider theme={theme}>
       <StyledLabel checked={props.checked || props.defaultChecked || false}>
-        <StyledInput
-          checked={props.checked}
-          disabled={props.disabled || false}
-          name={props.name}
-          onChange={props.onChange}
-          type="checkbox"
-          value={props.value}
-          ref={ref}
-        />
+        <StyledInput {...propsWithoutChildren} type="checkbox" ref={ref} />
         <SelectedBorder></SelectedBorder>
-        {props.children || props.value}
+        {children || props.value}
         {theme.utilities.useDefaultFromControls ? null : (
           <CheckWrapper>
             <Check>

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,12 +1,15 @@
-import React, { FC, InputHTMLAttributes } from 'react';
+import React, { FC, InputHTMLAttributes, Ref, forwardRef } from 'react';
 import { useTheme, ThemeProvider } from 'styled-components';
 
 import defaultTheme from 'src/themes/cruk';
+
 import { StyledLabel, StyledInput, SelectedBorder, CheckWrapper, Check, VerticalAlign } from './styles';
 
-type RadioProps = InputHTMLAttributes<HTMLInputElement>;
+type RadioProps = InputHTMLAttributes<HTMLInputElement> & {
+  ref?: Ref<HTMLInputElement>;
+};
 
-const RadioInput: FC<RadioProps> = props => {
+const RadioInput: FC<RadioProps> = forwardRef((props: RadioProps, ref?: Ref<HTMLInputElement>) => {
   const foundTheme = useTheme();
   const theme = {
     ...defaultTheme,
@@ -17,7 +20,7 @@ const RadioInput: FC<RadioProps> = props => {
   return (
     <ThemeProvider theme={theme}>
       <StyledLabel className={props.className} checked={props.checked || false}>
-        <StyledInput {...propsWithoutChildren} type="radio" />
+        <StyledInput {...propsWithoutChildren} type="radio" ref={ref} />
         <SelectedBorder></SelectedBorder>
         {theme.utilities.useDefaultFromControls ? null : (
           <CheckWrapper>
@@ -28,6 +31,6 @@ const RadioInput: FC<RadioProps> = props => {
       </StyledLabel>
     </ThemeProvider>
   );
-};
+});
 
 export default RadioInput;

--- a/src/components/TextAreaField/index.tsx
+++ b/src/components/TextAreaField/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement, TextareaHTMLAttributes } from 'react';
+import React, { FunctionComponent, ReactElement, TextareaHTMLAttributes, Ref, forwardRef } from 'react';
 import { useTheme } from 'styled-components';
 
 import defaultTheme from 'src/themes/cruk';
@@ -14,37 +14,36 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   label: string;
   resize?: 'both' | 'vertical' | 'horizontal' | 'none';
   lineCount?: number;
+  ref?: Ref<HTMLTextAreaElement>;
 };
 
-const TextField: FunctionComponent<Props> = ({
-  errorMessage,
-  hasError,
-  hintText,
-  label,
-  resize = 'vertical',
-  lineCount = 3,
-  ...props
-}) => {
-  const foundTheme = useTheme();
-  const theme = {
-    ...defaultTheme,
-    ...foundTheme,
-  };
+const TextField: FunctionComponent<Props> = forwardRef(
+  (
+    { errorMessage, hasError, hintText, label, resize = 'vertical', lineCount = 3, ...props }: Props,
+    ref?: Ref<HTMLTextAreaElement>,
+  ) => {
+    const foundTheme = useTheme();
+    const theme = {
+      ...defaultTheme,
+      ...foundTheme,
+    };
 
-  return (
-    <LabelWrapper label={label} hintText={hintText} required={props.required || false}>
-      <StyledTextArea
-        {...props}
-        aria-invalid={hasError || !!errorMessage || false}
-        hasError={hasError || !!errorMessage || false}
-        resize={resize}
-        lineCount={lineCount}
-        theme={theme}
-      />
-      {!!errorMessage && <ErrorText>{errorMessage}</ErrorText>}
-    </LabelWrapper>
-  );
-};
+    return (
+      <LabelWrapper label={label} hintText={hintText} required={props.required || false}>
+        <StyledTextArea
+          {...props}
+          aria-invalid={hasError || !!errorMessage || false}
+          hasError={hasError || !!errorMessage || false}
+          resize={resize}
+          lineCount={lineCount}
+          theme={theme}
+          ref={ref}
+        />
+        {!!errorMessage && <ErrorText>{errorMessage}</ErrorText>}
+      </LabelWrapper>
+    );
+  },
+);
 
 TextField.defaultProps = {
   lineCount: 3,


### PR DESCRIPTION
1) making sure all default InputHTMLAttributes props get passed to the styled input for checkbox, we were missing onBlur and a few others

2) allowing ref prop for radio and text area field components