### PR TITLE
RCL-1104 fix: update RFL logo source URL in site configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2025-10-29
+
+### Fixes
+
+- Update RFL header logo [#1104](https://github.com/CRUKorg/cruk-react-components/issues/1104)
+
 ## [6.1.1] - 2025-07-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "6.1.1",
+      "version": "6.1.2",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/themes/rfl.ts
+++ b/src/themes/rfl.ts
@@ -21,7 +21,7 @@ export const UTILITIES: UtilitiesType = {
 
 export const SITE_CONFIG: SiteConfigType = {
   ...defaultTheme.siteConfig,
-  logoSrc: "https://rcl.assets.cancerresearchuk.org/images/logos/rfl-sl.svg",
+  logoSrc: "https://rcl.assets.cancerresearchuk.org/images/logos/rfl.svg",
 };
 
 export const AVATAR: AvatarType = {


### PR DESCRIPTION
This pull request releases version 6.1.2 of the `@cruk/cruk-react-components` package, primarily addressing a bug related to the RFL header logo. The update ensures the correct logo is displayed for the RFL theme and documents the change in the changelog.

Bug fix:

* Updated the RFL theme's header logo source in `src/themes/rfl.ts` to use the correct SVG file.

Release and documentation:

* Bumped the package version to 6.1.2 in `package.json`.
* Added a changelog entry for version 6.1.2, documenting the RFL header logo fix.

fixes #1104 