### PR TITLE
fix: update step current dot styling to display a block of color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed the input labels to match helix designs in size and colors [#1117](https://github.com/CRUKorg/cruk-react-components/issues/1104)
+- Changed step current dot styling so that the dot shows a block of color [#1116](https://github.com/CRUKorg/cruk-react-components/issues/1104)
 
 ## [6.1.2] - 2025-10-29
 

--- a/src/components/Step/styles.ts
+++ b/src/components/Step/styles.ts
@@ -98,6 +98,7 @@ export const StepItem = styled.li<{
     css`
       ${StepBar} {
         border-color: ${theme.colors.tertiary};
+        background-color: ${theme.colors.tertiary};
       }
     `}
   ${({ $done, theme }) =>


### PR DESCRIPTION
This pull request updates the step indicator component to improve its visual styling, specifically focusing on the appearance of the current step's dot. The main change ensures that the current step's dot now displays as a solid block of color, aligning with updated design requirements.

Visual updates to step indicator:

* Changed the styling of the current step dot so that it now displays a block of color, providing clearer visual feedback for users. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13) [[2]](diffhunk://#diff-77cea02f1f3fd263758ea9e3541f50ba2a97707ebb7efdcb3bb8e45a97d71526R101)

fixes #1116 