### PR TITLE
RCL-1129 add font-smoothing to global styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.2.2] - 2025-12-02
 
+### Added
+
+- Added font-smoothing to global styles [#1129](https://github.com/CRUKorg/cruk-react-components/issues/1104)
+
+## [6.2.2] - 2025-12-02
+
 ### Fixes
 
 - More fixes for radio consent to handle smaller screen widths more gracefully [#1126](https://github.com/CRUKorg/cruk-react-components/issues/1104)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/GlobalStyle.tsx
+++ b/src/components/GlobalStyle.tsx
@@ -45,7 +45,7 @@ export const GlobalStyle = withTheme(createGlobalStyle`
         -ms-text-size-adjust: 100%;
         font-feature-settings: "kern";
         text-rendering: optimizeLegibility;
-        font-smoothing: antialiased;
+        -webkit-font-smoothing: antialiased;
       }
     `;
   }}

--- a/src/components/GlobalStyleNoFontFace.tsx
+++ b/src/components/GlobalStyleNoFontFace.tsx
@@ -22,6 +22,7 @@ export const GlobalStyleNoFontFace = withTheme(createGlobalStyle`
         -webkit-text-size-adjust: 100%;
         -moz-text-size-adjust: none;
         -ms-text-size-adjust: 100%;
+        -webkit-font-smoothing: antialiased;
       }
     `;
   }}


### PR DESCRIPTION
This pull request introduces a new global style for font smoothing and updates the package version. The most notable change is the addition of `-webkit-font-smoothing: antialiased;` to both global style components to improve font rendering, especially on webkit-based browsers.

Styling improvements:
* Added `-webkit-font-smoothing: antialiased;` to the `GlobalStyle` component for better font rendering in webkit browsers, replacing the non-standard `font-smoothing` property. (`src/components/GlobalStyle.tsx`)
* Added `-webkit-font-smoothing: antialiased;` to the `GlobalStyleNoFontFace` component for consistent font smoothing. (`src/components/GlobalStyleNoFontFace.tsx`)

Documentation:
* Updated the `CHANGELOG.md` to document the addition of font-smoothing to global styles.

Versioning:
* Bumped the package version from `6.2.2` to `6.2.3` in `package.json`.