### PR TITLE
fix: update popover styles and version to 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.1] - 2025-01-06
+
+### Removed
+
+- Fix visual issue with popover topleft arrow. [#1139](https://github.com/CRUKorg/cruk-react-components/issues/1139)
+
 ## [7.1.0] - 2025-01-06
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/PopOver/styles.css
+++ b/src/components/PopOver/styles.css
@@ -298,8 +298,8 @@
         rgba(0, 0, 0, 0.25);
       --_triangle-shadow-margin: 0 0 -1px 0;
 
-      --_triangle-border-color:
-        transparent transparent, var(--clr-popover-background, #fff);
+      --_triangle-border-color: transparent transparent
+        var(--clr-popover-background, #fff);
     }
   }
 


### PR DESCRIPTION
This pull request releases version 7.1.1, addressing a visual issue with the PopOver component's topleft arrow. The main focus is on fixing a CSS bug and updating versioning information.

Bug fix:

* Fixed the visual issue with the PopOver component's topleft arrow by correcting the `--_triangle-border-color` CSS variable in `src/components/PopOver/styles.css`.

Versioning and documentation:

* Updated the package version to `7.1.1` in `package.json`.
* Added a changelog entry for version 7.1.1, documenting the PopOver arrow fix.