### PR TITLE
fix: update Totaliser component styles and version to 7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] - 2025-01-07
+
+### Fixes
+
+- Fix visual issue with totaliser bubble arrow. [#1141](https://github.com/CRUKorg/cruk-react-components/issues/1141)
+
 ## [7.1.1] - 2025-01-06
 
-### Removed
+### Fixes
 
 - Fix visual issue with popover topleft arrow. [#1139](https://github.com/CRUKorg/cruk-react-components/issues/1139)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/Totaliser/styles.css
+++ b/src/components/Totaliser/styles.css
@@ -14,21 +14,21 @@
   }
 
   .progress-bar-wrapper {
-    padding: 0 46px 12px;
+    padding: 0;
     margin-top: var(--spacing-s, 1.5rem);
     position: relative;
 
     &:not([data-is-compact="true"]) {
-      padding: 0;
+      padding: 0 3rem 1rem;
       border: none;
       div > div > div:not(:first-child) {
         &:after {
           content: "▼";
           color: var(--clr-totaliser-bubble, #f2f2f2);
           position: absolute;
-          top: -36px;
-          right: -15px;
-          font-size: 32px;
+          top: -1.75rem;
+          right: -1rem;
+          font-size: 2rem;
         }
       }
     }


### PR DESCRIPTION
This pull request addresses a visual bug in the Totaliser component and updates the package version to reflect the fix. The main change is a CSS adjustment to the bubble arrow in the Totaliser, ensuring correct positioning and sizing. The change is documented in the changelog and the package version is incremented.

Bug fix and documentation:

* Fixed the visual issue with the Totaliser bubble arrow by adjusting the padding, position, and font size in `src/components/Totaliser/styles.css`.
* Added a changelog entry for version `7.1.2` documenting the Totaliser bubble arrow fix in `CHANGELOG.md`.

Version update:

* Bumped `package.json` version from `7.1.1` to `7.1.2` to release the fix.