### PR TITLE
feat: enhance Text component to support H tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.3] - 2025-01-07
+
+### Added
+
+- Better support for Text component as prop, which can now output as H tags. [#1143](https://github.com/CRUKorg/cruk-react-components/issues/1143)
+
 ## [7.1.2] - 2025-01-07
 
 ### Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.1.2",
+      "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -23,6 +23,10 @@ export default {
     textColor: "text-dark",
   },
   argTypes: {
+    as: {
+      control: "select",
+      options: ["", "p", "span", "div", "h1", "h2", "h3", "h4", "h5", "h6"],
+    },
     margin: {
       control: "select",
       options: ["none", "xxs", "xs", "s", "m", "l", "xl", "auto", ""],

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -38,8 +38,23 @@ export const Text = ({
   ColourProps &
   SpacingProps &
   TextProps & {
-    as?: "span" | "div" | "p" | "address";
-    ref?: Ref<HTMLSpanElement | HTMLDivElement | HTMLParagraphElement>;
+    as?:
+      | "span"
+      | "div"
+      | "p"
+      | "address"
+      | "h1"
+      | "h2"
+      | "h3"
+      | "h4"
+      | "h5"
+      | "h6";
+    ref?: Ref<
+      | HTMLSpanElement
+      | HTMLDivElement
+      | HTMLParagraphElement
+      | HTMLHeadingElement
+    >;
     style?: React.CSSProperties;
   }) => {
   const convertedProps = {
@@ -71,7 +86,7 @@ export const Text = ({
 
   return (
     <>
-      {(!as || as === "p") && (
+      {!as || as === "p" ? (
         <p
           className={[
             "component-text",
@@ -83,8 +98,8 @@ export const Text = ({
           {...htmlAttributes}
           {...convertedPropsFiltered}
         />
-      )}
-      {as === "div" && (
+      ) : null}
+      {as === "div" ? (
         <div
           className={[
             "component-text",
@@ -96,8 +111,8 @@ export const Text = ({
           {...htmlAttributes}
           {...convertedPropsFiltered}
         />
-      )}
-      {as === "span" && (
+      ) : null}
+      {as === "span" ? (
         <span
           className={[
             "component-text",
@@ -109,8 +124,8 @@ export const Text = ({
           {...htmlAttributes}
           {...convertedPropsFiltered}
         />
-      )}
-      {as === "address" && (
+      ) : null}
+      {as === "address" ? (
         <address
           className={[
             "component-text",
@@ -122,7 +137,85 @@ export const Text = ({
           {...htmlAttributes}
           {...convertedPropsFiltered}
         />
-      )}
+      ) : null}
+      {as === "h1" ? (
+        <h1
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
+      {as === "h2" ? (
+        <h2
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
+      {as === "h3" ? (
+        <h3
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
+      {as === "h4" ? (
+        <h4
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
+      {as === "h5" ? (
+        <h5
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
+      {as === "h6" ? (
+        <h6
+          className={[
+            "component-text",
+            "text-props",
+            "spacing-props",
+            "color-props",
+          ].join(" ")}
+          ref={ref as Ref<HTMLHeadingElement>}
+          {...htmlAttributes}
+          {...convertedPropsFiltered}
+        />
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
This pull request adds enhanced support for rendering the `Text` component as HTML heading tags (`h1`–`h6`). This allows consumers of the component library to use the `Text` component for semantic headings, improving accessibility and flexibility. The changes include updates to the component API, rendering logic, Storybook controls, and documentation.

**Text component improvements:**

* Extended the `as` prop in `src/components/Text/index.tsx` to support `"h1"` through `"h6"`, and updated the `ref` type to include `HTMLHeadingElement`. (`[src/components/Text/index.tsxL41-R57](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L41-R57)`)
* Updated the rendering logic in `src/components/Text/index.tsx` to handle all heading tags (`h1`–`h6`) and render the correct element based on the `as` prop. (`[[1]](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L74-R89)`, `[[2]](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L86-R102)`, `[[3]](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L99-R115)`, `[[4]](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L112-R128)`, `[[5]](diffhunk://#diff-a59d441d593fa035b47c2a6ed0bd7a8cd1c7ef981c7922d6eef1d751b44bf426L125-R218)`)

**Storybook and documentation updates:**

* Added heading tag options to the Storybook control for the `as` prop in `src/components/Text/Text.stories.tsx`, allowing users to select heading tags in the UI. (`[src/components/Text/Text.stories.tsxR26-R29](diffhunk://#diff-5972c0a39278e3e54030442e0e738d4084181e92d647a0dcbd3ee36145e209faR26-R29)`)
* Updated the changelog in `CHANGELOG.md` to document the new feature. (`[CHANGELOG.mdR8-R13](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)`)
* Bumped the package version to `7.1.3` in `package.json` to reflect the new feature release. (`[package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`)