### PR TITLE
RCL-1198 select font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.6] - 2026-06-29
+
+### Fixed
+
+- Fixed font weight in Select component [#1198](https://github.com/CRUKorg/cruk-react-components/issues/1196)
+
 ## [7.2.5] - 2026-06-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.2.5",
+      "version": "7.2.6",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/Select/styles.css
+++ b/src/components/Select/styles.css
@@ -53,6 +53,7 @@
   color: var(--_text-color, #000);
 
   font-family: var(--typ-font-family-base, "Poppins", Arial, sans-serif);
+  font-weight: var(--typ-font-weight-base, 400);
   font-size: var(--_font-size, 1rem);
 
   transition: border-color 150ms linear;


### PR DESCRIPTION
This pull request releases version `7.2.6` of the package, addressing a styling bug in the Select component. The main change ensures the Select component uses the correct font weight, improving visual consistency.

Bug fix:

* Updated the Select component’s CSS to explicitly set `font-weight` using the design system variable, ensuring consistent font rendering.

Release and documentation:

* Bumped the package version to `7.2.6` in `package.json`.
* Added a changelog entry for version `7.2.6` noting the Select component font weight fix.