### PR TITLE
RCL-1200 text field font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.7] - 2026-06-29
+
+### Fixed
+
+- Fixed font family in Text Field component [#1200](https://github.com/CRUKorg/cruk-react-components/issues/1200)
+
 ## [7.2.6] - 2026-06-29
 
 ### Fixed
 
-- Fixed font weight in Select component [#1198](https://github.com/CRUKorg/cruk-react-components/issues/1196)
+- Fixed font weight in Select component [#1198](https://github.com/CRUKorg/cruk-react-components/issues/1198)
 
 ## [7.2.5] - 2026-06-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.6",
+  "version": "7.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.2.6",
+      "version": "7.2.7",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.6",
+  "version": "7.2.7",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/Select/styles.css
+++ b/src/components/Select/styles.css
@@ -53,7 +53,7 @@
   color: var(--_text-color, #000);
 
   font-family: var(--typ-font-family-base, "Poppins", Arial, sans-serif);
-  font-weight: var(--typ-font-weight-base, 400);
+  font-weight: var(--typ-font-weight-base, 300);
   font-size: var(--_font-size, 1rem);
 
   transition: border-color 150ms linear;

--- a/src/components/TextField/styles.css
+++ b/src/components/TextField/styles.css
@@ -146,6 +146,7 @@
 
     line-height: var(--typ-line-height, 1.5em);
     font-size: var(--font-size-m, 1rem);
+    font-family: var(--typ-font-family-base, "Poppins", Arial, sans-serif);
 
     background-color: var(--_background-color, #ffffff);
     color: var(--_text-color, #000);


### PR DESCRIPTION
This pull request includes a patch release focused on fixing font-related issues in the `TextField` and `Select` components. The most important changes are:

Component style fixes:

* Added an explicit `font-family` to the `TextField` component to ensure consistent typography across browsers (`src/components/TextField/styles.css`).
* Changed the `font-weight` in the `Select` component from 400 to 300 to match the intended design specification (`src/components/Select/styles.css`).

Documentation and versioning:

* Updated the `CHANGELOG.md` to document the font family fix for the `TextField` component and corrected a reference for the previous `Select` component fix.
* Bumped the package version to `7.2.7` in `package.json` to reflect these changes.