### PR TITLE
RCL-1200 text field styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.8] - 2026-06-29
+
+### Fixed
+
+- Fixed font weight in Text Field component [#1200](https://github.com/CRUKorg/cruk-react-components/issues/1200)
+
 ## [7.2.7] - 2026-06-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cruk/cruk-react-components",
-      "version": "7.2.7",
+      "version": "7.2.8",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruk/cruk-react-components",
-  "version": "7.2.7",
+  "version": "7.2.8",
   "description": "React components implementing CRUK, RFL, SU2C & Bowelbabe designs",
   "license": "MIT",
   "publishConfig": {

--- a/src/components/TextAreaField/styles.css
+++ b/src/components/TextAreaField/styles.css
@@ -15,6 +15,7 @@
   display: block;
   font-family: var(--typ-font-family-base, "Poppins", Arial, sans-serif);
   font-size: var(--font-size-m, 1rem);
+  font-weight: var(--typ-font-weight-base, 300);
   padding: 6px 8px;
   width: 100%;
   transition: border-color 150ms linear;

--- a/src/components/TextField/styles.css
+++ b/src/components/TextField/styles.css
@@ -146,6 +146,7 @@
 
     line-height: var(--typ-line-height, 1.5em);
     font-size: var(--font-size-m, 1rem);
+    font-weight: var(--typ-font-weight-base, 300);
     font-family: var(--typ-font-family-base, "Poppins", Arial, sans-serif);
 
     background-color: var(--_background-color, #ffffff);


### PR DESCRIPTION
This pull request addresses a styling issue with the Text Field component and updates the package version. The main change ensures consistent font weight in both the `TextField` and `TextAreaField` components, improving visual consistency across the UI.

### Bug Fixes

* Added `font-weight: var(--typ-font-weight-base, 300);` to the `TextField` and `TextAreaField` CSS to fix incorrect font weight rendering. [[1]](diffhunk://#diff-326ab5830b02e44437c1227446c0c0de250125d75274ebb6987ba94dcddfcdefR149) [[2]](diffhunk://#diff-ef7d862f177f82eb855b1e2416a665f6227e577903ffe043d8b50e1ad86aa389R18)

### Documentation

* Updated `CHANGELOG.md` to document the font weight fix for the Text Field component under version 7.2.8.

### Versioning

* Bumped the package version to `7.2.8` in `package.json` to reflect the new fix.