### PR TITLE
TS 7 prep

### DIFF
--- a/playwright/utils.tsx
+++ b/playwright/utils.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { AxeBuilder } from "@axe-core/playwright";
 import React from "react";
-import { type ThemeNameType, themeNames } from "src/types";
+import { type ThemeNameType, themeNames } from "../src/types";
 
 export function testAccessibilityForTheme({
   componentName,

--- a/src/components/AddressLookup/AddressLookup.spec.tsx
+++ b/src/components/AddressLookup/AddressLookup.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { AddressLookup } from ".";
 import "./styles.css";

--- a/src/components/Avatar/Avatar.spec.tsx
+++ b/src/components/Avatar/Avatar.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 import { Avatar } from ".";
 import "./styles.css";
 

--- a/src/components/Badge/Badge.spec.tsx
+++ b/src/components/Badge/Badge.spec.tsx
@@ -7,7 +7,7 @@ import {
   faBullhorn,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Badge } from ".";
 import { IconFa } from "..";

--- a/src/components/Box/Box.spec.tsx
+++ b/src/components/Box/Box.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Box } from ".";
 import { Text } from "..";

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -5,7 +5,7 @@ import {
   faPenToSquare,
 } from "@fortawesome/free-solid-svg-icons";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Button } from ".";
 import { IconFa, Box } from "..";

--- a/src/components/Carousel/Carousel.spec.tsx
+++ b/src/components/Carousel/Carousel.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Carousel } from ".";
 import { Text } from "..";

--- a/src/components/Checkbox/Checkbox.spec.tsx
+++ b/src/components/Checkbox/Checkbox.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Box } from "../Box";
 import { TestThemeWrapper } from "../AllThemesWrapper";

--- a/src/components/Checkbox/styles.css
+++ b/src/components/Checkbox/styles.css
@@ -124,10 +124,9 @@
       .check {
         border-color: var(--clr-danger, #ff0000);
         background-color: var(--clr-background-light, #fff);
-
         svg {
           path {
-            fill: var(--clr-danger, #ff0000);
+            fill: var(--clr-danger, #ff0000) !important;
             transform: rotateY(0deg);
           }
         }

--- a/src/components/Collapse/Collapse.spec.tsx
+++ b/src/components/Collapse/Collapse.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Text, Box } from "..";
 import { Collapse } from ".";

--- a/src/components/DateField/DateField.spec.tsx
+++ b/src/components/DateField/DateField.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Box } from "..";
 import { DateField } from ".";

--- a/src/components/ErrorText/ErrorText.spec.tsx
+++ b/src/components/ErrorText/ErrorText.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { ErrorText } from ".";
 import "./styles.css";

--- a/src/components/Footer/Footer.spec.tsx
+++ b/src/components/Footer/Footer.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Footer } from ".";
 import { Link } from "..";

--- a/src/components/Header/Header.spec.tsx
+++ b/src/components/Header/Header.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Button } from "..";
 import { Header } from ".";

--- a/src/components/Heading/Heading.spec.tsx
+++ b/src/components/Heading/Heading.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Heading } from ".";
 import "./styles.css";

--- a/src/components/IconFa/IconFa.spec.tsx
+++ b/src/components/IconFa/IconFa.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { faBullseye } from "@fortawesome/free-solid-svg-icons";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { IconFa } from ".";
 import "./styles.css";

--- a/src/components/IconFa/index.tsx
+++ b/src/components/IconFa/index.tsx
@@ -6,7 +6,7 @@ import {
   themeSpacingSizeOrString,
 } from "../../utils/themeUtils";
 
-import { type spaces, type colours } from "src/types";
+import { type spaces, type colours } from "../../types";
 
 /**
  * The IconFa component (Icon Font Awesome) displays an icon glyph as an `<svg>` element.

--- a/src/components/InfoBox/InfoBox.spec.tsx
+++ b/src/components/InfoBox/InfoBox.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { IconFa, Text } from "..";
 import { InfoBox } from ".";

--- a/src/components/LegendWrapper/LegendWrapper.spec.tsx
+++ b/src/components/LegendWrapper/LegendWrapper.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Heading, Box, Radio, Checkbox } from "..";
 import { LegendWrapper } from ".";

--- a/src/components/Link/Link.spec.tsx
+++ b/src/components/Link/Link.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Link } from ".";
 import "./styles.css";

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -4,7 +4,11 @@ import React, {
   type ReactNode,
 } from "react";
 
-import { type ColourProps, type SpacingProps, type TextProps } from "src/types";
+import {
+  type ColourProps,
+  type SpacingProps,
+  type TextProps,
+} from "../../types";
 
 export type LinkProps = Omit<AnchorHTMLAttributes<HTMLElement>, "nonce"> &
   SpacingProps &

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Loader } from ".";
 import "./styles.css";

--- a/src/components/Modal/Modal.spec.tsx
+++ b/src/components/Modal/Modal.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 
-import { testAccessibilityForTheme } from "playwright/utils";
+import { testAccessibilityForTheme } from "../../../playwright/utils";
 import { TestThemeWrapper } from "../AllThemesWrapper";
 
 import { TestModalWithOpenButton } from "./TestModalWithOpenButton";

--- a/src/components/Pagination/Pagination.spec.tsx
+++ b/src/components/Pagination/Pagination.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Pagination } from ".";
 import "./styles.css";

--- a/src/components/ProgressBar/ProgressBar.spec.tsx
+++ b/src/components/ProgressBar/ProgressBar.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Text } from "..";
 import { ProgressBar } from ".";

--- a/src/components/Radio/Radio.spec.tsx
+++ b/src/components/Radio/Radio.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Radio } from ".";
 import "./styles.css";

--- a/src/components/RadioConsent/RadioConsent.spec.tsx
+++ b/src/components/RadioConsent/RadioConsent.spec.tsx
@@ -1,6 +1,6 @@
 import React, { type ChangeEvent } from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { RadioConsent } from ".";
 import "./styles.css";

--- a/src/components/Select/Select.spec.tsx
+++ b/src/components/Select/Select.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Box, Button } from "..";
 import { TestThemeWrapper } from "../AllThemesWrapper";

--- a/src/components/Step/Step.spec.tsx
+++ b/src/components/Step/Step.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Step } from ".";
 import "./styles.css";

--- a/src/components/Text/Text.spec.tsx
+++ b/src/components/Text/Text.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Text } from ".";
 import "./styles.css";

--- a/src/components/TextAreaField/TextAreaField.spec.tsx
+++ b/src/components/TextAreaField/TextAreaField.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { TextAreaField } from ".";
 import "./styles.css";

--- a/src/components/TextField/TextField.spec.tsx
+++ b/src/components/TextField/TextField.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Heading, Box, Button, IconFa } from "..";
 import { TextField } from ".";

--- a/src/components/Totaliser/Totaliser.spec.tsx
+++ b/src/components/Totaliser/Totaliser.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { Box, Text } from "..";
 import { Totaliser } from ".";

--- a/src/components/UserBlock/UserBlock.spec.tsx
+++ b/src/components/UserBlock/UserBlock.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { testAccessibilityOnAllThemes } from "playwright/utils";
+import { testAccessibilityOnAllThemes } from "../../../playwright/utils";
 
 import { UserBlock } from ".";
 import "./styles.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "esnext",
     "jsx": "react",
     "moduleResolution": "bundler",
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "lib": ["dom", "es2015", "es2016"],
-    "baseUrl": "./",
+    "rootDir": "./",
     "allowJs": false, //Only TS and TSX will be compiled.
     "noImplicitAny": true, // Setting to true means if no type given it will not automatically assign ANY.
     "noUnusedLocals": true,
@@ -23,7 +23,7 @@
       "name": "typescript-plugin-css-modules",
       "options": {
         "customMatcher": "\\.module\\.css$",
-        "classNameTransfrom": "dashes"
+        "classNameTransform": "dashes"
       }
     }
   ],


### PR DESCRIPTION
This pull request updates import paths in the codebase to use relative imports instead of module-based imports for shared utilities and types. This change improves module resolution reliability, especially in test files, by ensuring that imports reference the correct local files regardless of the test runner's working directory.

**Test utility import path updates:**

* Changed all imports of `testAccessibilityOnAllThemes` in component spec files (e.g., `Button.spec.tsx`, `Box.spec.tsx`, etc.) from `"playwright/utils"` to `"../../../playwright/utils"` to use a relative path. [[1]](diffhunk://#diff-1ea575748caafac1b77314f747222a713c0f399409410cb448642a6bbb992a67L4-R4) [[2]](diffhunk://#diff-c13c35fa9c2e910afe12bd311ca02afce03a44a5a884df19a902de52eb610777L3-R3) [[3]](diffhunk://#diff-6e7acaa0c852afc401c6b750e85a790eff2c4a8c500a8d9d0d1c0fc427cde273L10-R10) [[4]](diffhunk://#diff-fb8cdd59030bb9f900c44c87b50fad3c66d1ab95c0f65635681c9c75482b3179L3-R3) [[5]](diffhunk://#diff-38300f4553242dd557102cb3d8fa9ae05356cd2e693af5c21673b1579643325cL8-R8) [[6]](diffhunk://#diff-99790ca961b1ac346a600746b1e6089519ff0643343c0071ab4e5e4bf9691493L3-R3) [[7]](diffhunk://#diff-d120aa4d34a920fb6c902530fa7f4c32ec6548ed1afd93841d5dcc2fcda23985L4-R4) [[8]](diffhunk://#diff-5ad558cd426afd8687a08cc044421190d5b01da84731140b4c4616e3ad000631L3-R3) [[9]](diffhunk://#diff-880f51c0241c3b4e970752e0c60b0314ef7e3c84a82af58e43189c5e74bafadfL3-R3) [[10]](diffhunk://#diff-18c87a34ac084b6b6635c416aa9f9160c1a565ffcca4b3aa22412a48a059da0dL3-R3) [[11]](diffhunk://#diff-3abce1a0c90baf786b0873abdc2892c5b9e192f4420571317a1c49572bc7d3a8L3-R3) [[12]](diffhunk://#diff-eee5a49bbb6d5acd3a4afca78cf1c6c89b7a229de8bcb3ea290799ce1ae40448L4-R4) [[13]](diffhunk://#diff-d388969833ee390930d685c8fb777f429ba915b560cf31350e9cd0226dcf95c1L3-R3) [[14]](diffhunk://#diff-19892166323fb86ae1428274ce1ec21382bfe7028233a96743dba90dd2c696faL4-R4) [[15]](diffhunk://#diff-336f202e07ee2652b9d76394f7cb932036e53c0c6f8177bf83aa2fb68de85d98L4-R4) [[16]](diffhunk://#diff-df73eb85d37c854a66758f54e5be151b3ee854b7e86a0c0bb23b84a208c5448eL3-R3) [[17]](diffhunk://#diff-70cfe0b20a9187f21de7ab8d54e5a6aa0977dd4d399516a967d51dca5e9a6e73L3-R3) [[18]](diffhunk://#diff-fdf6adee35291d1ed965205fbae29dc89d765e48e1d912bfefc8c68374524bd2L3-R3)

**Type import path corrections:**

* Updated imports of types such as `ThemeNameType`, `themeNames`, `spaces`, and `colours` to use relative paths (e.g., `"../src/types"` or `"../../types"`) instead of module-based paths like `"src/types"` in both utility and component files. [[1]](diffhunk://#diff-4200070e32adb42010855b086647b1ed89fc2444762bca4d204f9dee3143830eL4-R4) [[2]](diffhunk://#diff-db5f9ae0a749127b3c708cd981a19c0c12dfd4e2763d065328b86fa842fd930eL9-R9)